### PR TITLE
docs: PROJECT-CONTEXT region → us-east1 + Storage live

### DIFF
--- a/PROJECT-CONTEXT.md
+++ b/PROJECT-CONTEXT.md
@@ -61,8 +61,8 @@ kehila2026-Dkhefa-lhagshama/
 - **Frontend:** React 18 + **Next.js (Pages Router)** + Tailwind CSS + custom `LanguageContext` for HE / EN + Lucide icons. Lives in `frontend/`.
 - **Backend:** **Node.js + Express + Firebase Admin SDK**. Lives in `backend/`. The frontend talks to the backend over HTTP via the `NEXT_PUBLIC_API_BASE_URL` env var.
 - **Auth:** Firebase Auth (Email/Password) with custom claims for roles (`beneficiary | businessOwner | volunteer | admin`).
-- **Data:** Firestore in `europe-west2` region.
-- **File storage:** Firebase Storage (deferred until UC-01 file uploads land — requires Blaze plan upgrade).
+- **Data:** Firestore in `us-east1` region.
+- **File storage:** Firebase Storage in `us-east1` (co-located with Firestore; Blaze plan is active).
 - **Deploy target:** Firebase Hosting for the frontend; Cloud Run or Vercel for the backend (decision in Week 5).
 - **Testing:** Jest / Vitest for unit tests; `@firebase/rules-unit-testing` for Firestore rules; Playwright optional for E2E.
 


### PR DESCRIPTION
## Summary
- Firestore region: `europe-west2` → **`us-east1`** (was recreated to co-locate with Storage)
- Storage status: marked as **live in us-east1 on Blaze**, no longer "deferred"

## Why
Storage's default-bucket region was set to `us-east1` (free tier). Firestore was originally in `europe-west2`. We chose to align both in `us-east1` rather than pay cross-region latency on every UC-01 attachment write. Firestore region is immutable per-database, so the `(default)` database was deleted (empty — no data loss) and recreated in `us-east1`. Rules redeployed.

## Verification
- [x] `firebase deploy --only firestore:rules` succeeded against the new us-east1 database
- [x] `firebase deploy --only storage` succeeded
- [x] `firebase.json` updated on the M0 branch (separate PR)

## Test plan
- [x] PROJECT-CONTEXT.md reflects current infrastructure
- [ ] Reviewer confirms no remaining `europe-west2` references in the team-monorepo docs