### PR TITLE
chore: add Firestore taxonomy seed script (categories + regions)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,8 @@
     "start": "node dist/index.js",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "seed": "ts-node --project tsconfig.scripts.json scripts/seed.ts"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/backend/scripts/seed.ts
+++ b/backend/scripts/seed.ts
@@ -1,0 +1,63 @@
+import 'dotenv/config';
+import { initializeFirebaseAdmin, db } from '../src/lib/firebaseAdmin';
+
+initializeFirebaseAdmin();
+const firestore = db();
+
+interface TaxonomyEntry {
+  id: string;
+  nameHe: string;
+  nameEn: string;
+}
+
+const CATEGORIES: TaxonomyEntry[] = [
+  { id: 'employment',  nameHe: 'תעסוקה',           nameEn: 'Employment' },
+  { id: 'education',   nameHe: 'השכלה',            nameEn: 'Education' },
+  { id: 'legal',       nameHe: 'משפטי',            nameEn: 'Legal' },
+  { id: 'housing',     nameHe: 'דיור',             nameEn: 'Housing' },
+  { id: 'health',      nameHe: 'בריאות',           nameEn: 'Health' },
+  { id: 'social',      nameHe: 'שירותים חברתיים',  nameEn: 'Social Services' },
+  { id: 'welfare',     nameHe: 'רווחה',            nameEn: 'Welfare' },
+  { id: 'absorption',  nameHe: 'קליטת עלייה',      nameEn: 'Immigration & Absorption' },
+  { id: 'community',   nameHe: 'קהילה',            nameEn: 'Community' },
+  { id: 'youth',       nameHe: 'נוער',             nameEn: 'Youth' },
+];
+
+const REGIONS: TaxonomyEntry[] = [
+  { id: 'jerusalem',   nameHe: 'ירושלים',          nameEn: 'Jerusalem' },
+  { id: 'north',       nameHe: 'צפון',             nameEn: 'North' },
+  { id: 'haifa',       nameHe: 'חיפה',             nameEn: 'Haifa' },
+  { id: 'tel-aviv',    nameHe: 'תל אביב',          nameEn: 'Tel Aviv' },
+  { id: 'center',      nameHe: 'מרכז',             nameEn: 'Center' },
+  { id: 'south',       nameHe: 'דרום',             nameEn: 'South' },
+  { id: 'negev',       nameHe: 'נגב',              nameEn: 'Negev' },
+  { id: 'galilee',     nameHe: 'גליל',             nameEn: 'Galilee' },
+  { id: 'sharon',      nameHe: 'שרון',             nameEn: 'Sharon' },
+  { id: 'shfela',      nameHe: 'שפלה',             nameEn: 'Lowlands' },
+];
+
+async function seedCollection(
+  collectionName: string,
+  entries: TaxonomyEntry[],
+): Promise<void> {
+  const batch = firestore.batch();
+  for (const entry of entries) {
+    const ref = firestore.collection(collectionName).doc(entry.id);
+    batch.set(ref, { nameHe: entry.nameHe, nameEn: entry.nameEn }, { merge: true });
+  }
+  await batch.commit();
+  console.log(`  ✓ ${collectionName}: ${entries.length} documents seeded`);
+}
+
+async function main(): Promise<void> {
+  console.log('Seeding Firestore taxonomy...');
+  await seedCollection('categories', CATEGORIES);
+  await seedCollection('regions', REGIONS);
+  console.log('Done.');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Seed failed:', err);
+  process.exit(1);
+});

--- a/backend/tsconfig.scripts.json
+++ b/backend/tsconfig.scripts.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist-scripts"
+  },
+  "include": ["src/**/*", "scripts/**/*"]
+}


### PR DESCRIPTION
Closes #22

- backend/scripts/seed.ts writes 10 categories and 10 regions using the existing firebaseAdmin helpers; deterministic doc IDs + set/merge make it safe to re-run
- tsconfig.scripts.json extends the main tsconfig with rootDir "." so scripts/ can import from src/lib without breaking the main build
- Adds "seed" npm script: npm run seed

<!-- Thanks for the PR! Fill in each section. Delete the comment lines as you go. -->

## Summary
<!-- 1–3 sentences describing what changed and why. -->


## Linked Issue
<!-- e.g. Closes #12  (use "Closes" so GitHub auto-closes when merged) -->
Closes #


## Changes
<!-- Bullet list of the actual changes in this PR. -->
- 


## Test Plan
<!-- How does the reviewer verify this works? -->
- [ ] 
- [ ] 


## Screenshots / GIFs
<!-- For UI changes — drag and drop into this section.
     For backend-only changes, delete this section. -->


## Checklist
- [ ] Branch follows naming (`feat/...`, `fix/...`, `docs/...`, `chore/...`)
- [ ] Lint + build pass locally
- [ ] HE/EN strings go through the translation layer (if UI change)
- [ ] Firestore rules updated if schema/access changed
- [ ] No secrets in the diff (no service-account JSON, no `.env` values)
- [ ] At least one reviewer requested
