### PR TITLE
feat(uc-01): POST /api/requests + Firestore rules (closes #27, #28)

### DIFF
--- a/backend/docs/patterns.md
+++ b/backend/docs/patterns.md
@@ -1,19 +1,151 @@
 # Backend Patterns — Reference for Vertical-Slice Owners
 
-> Filled in as soon as **UC-01 Submit Request** lands. The first vertical slice acts as the reference pattern; the other 3 owners (UC-02/UC-03 Hamza, UC-04 Mhammad, UC-05 Abdullah) follow the same shape so the codebase stays consistent.
+The Express backend follows one shape so every vertical slice (UC-01..UC-05) looks the same. Read this before writing a new route file. `POST /api/requests` is the canonical reference — copy it.
 
-This is a placeholder. After UC-01-c lands (Express `POST /api/requests`), Muhammad Marmash will fill this with:
+## File layout
 
-1. **Route file shape** — imports, router export, middleware order.
-2. **Zod input validation pattern** — schema definition + `safeParse` + 400 response shape.
-3. **Auth + role-gating pattern** — `authenticate` then `requireRole(...)` if needed.
-4. **Firestore write pattern** — using `db()` from `lib/firebaseAdmin`, `serverTimestamp()`, transaction usage.
-5. **Audit log pattern** — when to call `writeAuditLog`.
-6. **Error response shape** — consistent JSON error format across endpoints.
-7. **Frontend fetch pattern** — how the Next.js side attaches the Firebase ID token.
+```
+backend/src/
+├── index.ts                # Express bootstrap, mounts routers
+├── lib/
+│   ├── firebaseAdmin.ts    # initializeFirebaseAdmin(), db(), auth(), storage()
+│   └── audit.ts            # writeAuditLog({ actorId, action, entityType, entityId, details })
+├── middleware/
+│   └── auth.ts             # authenticate, requireRole('admin'|...), req.user = { uid, email, role }
+└── routes/
+    ├── auth.ts             # POST /api/auth/register     (CC-5)
+    ├── requests.ts         # /api/requests/*             (UC-01)
+    └── ... your UC here ...
+```
 
-Until this is filled, the only canonical references are:
-- [`src/index.ts`](../src/index.ts) — Express bootstrap.
-- [`src/middleware/auth.ts`](../src/middleware/auth.ts) — token verify and `requireRole`.
-- [`src/lib/firebaseAdmin.ts`](../src/lib/firebaseAdmin.ts) — Admin SDK handles.
-- [`src/lib/audit.ts`](../src/lib/audit.ts) — audit log writer.
+## Route file shape
+
+Every route file exports a `Router` and is mounted in `src/index.ts` under `/api/<resource>`.
+
+```ts
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+import { db } from '@/lib/firebaseAdmin';
+import { writeAuditLog } from '@/lib/audit';
+import { authenticate, requireRole } from '@/middleware/auth';
+
+const router = Router();
+
+// One zod schema per endpoint, defined at file top.
+const createXSchema = z.object({ /* ... */ });
+
+router.post('/', authenticate, /* requireRole('admin') if applicable */, async (req: Request, res: Response) => {
+  // 1. Bail if no user (defense in depth — authenticate already checks).
+  if (!req.user) { res.status(401).json({ error: 'not_authenticated' }); return; }
+
+  // 2. Validate body with zod.
+  const parsed = createXSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'validation', fieldErrors: parsed.error.flatten().fieldErrors });
+    return;
+  }
+
+  // 3. Do the work (Firestore write, etc.). Use try/catch around create().
+  // 4. Fire-and-forget audit log on success.
+  // 5. 201 / 200 with minimal payload.
+});
+
+export default router;
+```
+
+## Zod validation
+
+- One schema per endpoint, at file top.
+- Use `.trim().min().max()` on strings; `.coerce.number()` for numeric form fields; `.enum()` for finite vocabularies; `.literal(true)` for consent flags.
+- Always use `.safeParse(...)` — never `.parse(...)` — so the handler doesn't throw 500 on bad input.
+- Error shape: `{ error: 'validation', fieldErrors: parsed.error.flatten().fieldErrors }`.
+
+## Auth + role gating
+
+- `authenticate` is required on every non-public route. It verifies the Firebase ID token from `Authorization: Bearer <token>` and attaches `req.user = { uid, email, role }`.
+- For admin-only routes: chain `requireRole('admin')` after `authenticate`.
+- For "beneficiary OR volunteer" gating, **don't** use `requireRole` — write an inline check (see `routes/requests.ts`).
+
+## Firestore writes
+
+- Use `db().collection(...).doc(id).create(data)` rather than `.set(data)` when you want to **reject duplicates** loudly. `create()` throws gRPC code 6 (`ALREADY_EXISTS`); convert to 409.
+- Use `FieldValue.serverTimestamp()` for `createdAt`/`updatedAt`. Never `new Date()` server-side.
+- Reads in routes should respect the security rules logically — if `firestore.rules` denies a read for the caller, the API should also return 403 (defense in depth).
+
+## Audit log
+
+Every server-trusted write should write an audit log entry. Use `writeAuditLog`:
+
+```ts
+writeAuditLog({
+  actorId: req.user.uid,
+  action: 'request.create',         // 'noun.verb' format
+  entityType: 'requests',
+  entityId: input.requestId,
+  details: { /* small JSON */ },
+}).catch((err) => console.error('audit failed:', err));
+```
+
+Fire-and-forget — never block the response on the audit write. If the log fails the user already got their 201; we just lose one entry.
+
+## Error response shape
+
+Use these consistent shapes so the frontend can react sensibly:
+
+| Status | Body | When |
+|---|---|---|
+| 400 | `{ error: 'validation', fieldErrors: {...} }` | zod failure |
+| 401 | `{ error: 'missing_token' \| 'invalid_token' }` | from `authenticate` |
+| 403 | `{ error: 'forbidden', detail?: string }` | role mismatch |
+| 404 | `{ error: 'not_found' }` | unknown doc |
+| 409 | `{ error: 'duplicate_<resource>_id' }` | Firestore ALREADY_EXISTS |
+| 500 | `{ error: 'internal' }` | unexpected — also `console.error` the cause |
+
+## Frontend fetch pattern
+
+The Next.js side uses `apiFetch(path, init)` from `frontend/src/lib/apiClient.ts`. It automatically attaches `Authorization: Bearer ${idToken}` for the signed-in user. **Never call `fetch()` directly** from a Next.js page that needs auth.
+
+```ts
+import { apiFetch } from '@/lib/apiClient';
+
+const res = await apiFetch('/api/requests', {
+  method: 'POST',
+  body: JSON.stringify(payload),
+});
+if (!res.ok) { /* show validation/error UX */ }
+```
+
+## End-to-end smoke test — UC-01
+
+Reproducible from the CLI. Boot the backend (`npm run dev` in `backend/`) and the frontend (`npm run dev` in `frontend/`). Then in a browser, register a user via `/register` and copy the ID token from devtools (or call `firebase.auth().currentUser.getIdToken().then(console.log)` in the console).
+
+```bash
+TOKEN="<paste-id-token-here>"
+REQ_ID=$(node -e "console.log(crypto.randomUUID())")
+
+curl -i -X POST http://localhost:3001/api/requests \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"requestId\":\"$REQ_ID\",
+    \"firstName\":\"Test\",\"lastName\":\"User\",
+    \"idNumber\":\"123456789\",\"phone\":\"050-0000000\",
+    \"email\":\"test@example.com\",\"city\":\"תל אביב\",
+    \"age\":30,\"gender\":\"other\",
+    \"category\":\"education\",
+    \"description\":\"Need help applying for a scholarship.\",
+    \"urgency\":\"low\",
+    \"consent\":true
+  }"
+# Expected: HTTP/1.1 201 Created
+# {"requestId":"<uuid>"}
+```
+
+Then check the Firestore console for `requests/<uuid>` with `status: pending`, `beneficiaryId: <your-uid>`, and `auditLogs/...` for the matching `request.create` entry.
+
+**Failure modes worth testing manually:**
+
+- Omit `Authorization` → 401 `missing_token`.
+- Set `consent: false` → 400 `validation` with `fieldErrors.consent`.
+- Send a description shorter than 10 chars → 400 `validation`.
+- POST the same `requestId` twice → 409 `duplicate_request_id`.

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,6 +12,7 @@ import express, { Request, Response } from 'express';
 
 import { initializeFirebaseAdmin } from '@/lib/firebaseAdmin';
 import authRouter from '@/routes/auth';
+import requestsRouter from '@/routes/requests';
 import { authenticate } from '@/middleware/auth';
 
 const PORT = Number(process.env.PORT ?? 3001);
@@ -43,15 +44,14 @@ app.get('/api/me', authenticate, (req: Request, res: Response) => {
 });
 
 // Route mounts — uncomment as each vertical-slice UC lands.
-app.use('/api/auth', authRouter);
+app.use('/api/auth',     authRouter);
+app.use('/api/requests', requestsRouter);
 //
-// import requestsRouter from '@/routes/requests';      // UC-01
 // import answersRouter from '@/routes/answers';        // UC-02
 // import businessesRouter from '@/routes/businesses';  // UC-03
 // import chatsRouter from '@/routes/chats';            // UC-04
 // import adminRouter from '@/routes/admin';            // UC-05
 //
-// app.use('/api/requests',   requestsRouter);
 // app.use('/api/answers',    answersRouter);
 // app.use('/api/businesses', businessesRouter);
 // app.use('/api/chats',      chatsRouter);

--- a/backend/src/routes/requests.ts
+++ b/backend/src/routes/requests.ts
@@ -1,0 +1,170 @@
+/**
+ * /api/requests — UC-01 Submit Assistance Request.
+ *
+ * All writes go through the Admin SDK (which bypasses Firestore rules).
+ * The client never writes to /requests directly — rules `allow create: if false`.
+ *
+ * Roles allowed to submit:
+ *   - beneficiary: submitting for themselves
+ *   - volunteer:   submitting on behalf of a beneficiary (UC-01 alt flow A2);
+ *                  the volunteer's uid is recorded as the actor; `onBehalfOf`
+ *                  holds the target beneficiary uid if known.
+ *
+ * Admin can read everything via UC-05; rules + GET /api/requests/:id enforce.
+ */
+import { FieldValue } from 'firebase-admin/firestore';
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+
+import { db } from '@/lib/firebaseAdmin';
+import { writeAuditLog } from '@/lib/audit';
+import { authenticate } from '@/middleware/auth';
+
+const router = Router();
+
+// ── Schema ────────────────────────────────────────────────────────────────
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const createRequestSchema = z.object({
+  // Client-generated UUID, used as both Firestore doc id and Storage path prefix.
+  // Using `create()` server-side rejects duplicate ids loudly.
+  requestId: z.string().regex(UUID_V4, 'requestId must be a v4 UUID'),
+
+  // Personal info
+  firstName: z.string().trim().min(1).max(80),
+  lastName:  z.string().trim().min(1).max(80),
+  idNumber:  z.string().trim().min(1).max(40),
+  phone:     z.string().trim().min(1).max(40),
+  email:     z.string().trim().email().max(120),
+  city:      z.string().trim().min(1).max(80),
+  age:       z.coerce.number().int().min(0).max(120),
+  gender:    z.enum(['male', 'female', 'other', '']).default(''),
+
+  // Request body
+  category:    z.enum(['education', 'employment', 'legal', 'social']),
+  description: z.string().trim().min(10).max(4000),
+  urgency:     z.enum(['low', 'medium', 'high']).default('low'),
+
+  // Consent — must be true. Aligns with wiki UC-01 step 4.
+  consent: z.literal(true, {
+    errorMap: () => ({ message: 'consent must be true' }),
+  }),
+
+  // Optional Storage paths under requests/{requestId}/...
+  attachmentPaths: z.array(z.string().min(1)).max(20).optional().default([]),
+
+  // Volunteer-on-behalf alt flow (UC-01 A2). Full UX deferred; schema scaffolded.
+  onBehalfOf: z
+    .object({
+      uid: z.string().min(1).optional(),
+    })
+    .optional(),
+});
+
+type CreateRequestInput = z.infer<typeof createRequestSchema>;
+
+// ── POST /api/requests ────────────────────────────────────────────────────
+router.post('/', authenticate, async (req: Request, res: Response) => {
+  if (!req.user) {
+    res.status(401).json({ error: 'not_authenticated' });
+    return;
+  }
+
+  // Role gate. Beneficiary submits for self; volunteer can submit on behalf.
+  // We don't `requireRole('beneficiary')` because that would block volunteers.
+  const role = req.user.role;
+  if (role !== 'beneficiary' && role !== 'volunteer') {
+    res.status(403).json({
+      error: 'forbidden',
+      detail: 'submitting requests requires the beneficiary or volunteer role',
+    });
+    return;
+  }
+
+  const parsed = createRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({
+      error: 'validation',
+      fieldErrors: parsed.error.flatten().fieldErrors,
+    });
+    return;
+  }
+
+  const input: CreateRequestInput = parsed.data;
+
+  // The beneficiaryId is the target user. For a volunteer submitting on behalf
+  // with a known uid, use that; otherwise the beneficiary is the caller (the
+  // common case — UC-01 main flow).
+  const beneficiaryId =
+    role === 'volunteer' && input.onBehalfOf?.uid ? input.onBehalfOf.uid : req.user.uid;
+
+  const docRef = db().collection('requests').doc(input.requestId);
+
+  try {
+    await docRef.create({
+      beneficiaryId,
+      submittedBy: req.user.uid,             // who actually pressed submit
+      submittedByRole: role,                 // 'beneficiary' or 'volunteer'
+
+      // Personal info snapshot at submit time
+      firstName: input.firstName,
+      lastName:  input.lastName,
+      idNumber:  input.idNumber,
+      phone:     input.phone,
+      email:     input.email,
+      city:      input.city,
+      age:       input.age,
+      gender:    input.gender,
+
+      // Body
+      category:    input.category,
+      description: input.description,
+      urgency:     input.urgency,
+
+      // Lifecycle
+      status:      'pending',
+      handler:     null,
+      notes:       '',
+
+      // Attachments
+      attachmentPaths: input.attachmentPaths ?? [],
+
+      // Timestamps
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+  } catch (err) {
+    // `create()` throws ALREADY_EXISTS (gRPC code 6) if the doc already exists.
+    const code = (err as { code?: number }).code;
+    if (code === 6) {
+      res.status(409).json({ error: 'duplicate_request_id' });
+      return;
+    }
+    // eslint-disable-next-line no-console
+    console.error('[requests.create] failed:', err);
+    res.status(500).json({ error: 'internal' });
+    return;
+  }
+
+  // Audit log — fire-and-forget. Don't block the response on it; surface in
+  // server logs if it fails.
+  writeAuditLog({
+    actorId: req.user.uid,
+    action: 'request.create',
+    entityType: 'requests',
+    entityId: input.requestId,
+    details: {
+      beneficiaryId,
+      category: input.category,
+      urgency:  input.urgency,
+      hasAttachments: (input.attachmentPaths?.length ?? 0) > 0,
+    },
+  }).catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error('[requests.create] audit write failed:', err);
+  });
+
+  res.status(201).json({ requestId: input.requestId });
+});
+
+export default router;

--- a/firestore.rules
+++ b/firestore.rules
@@ -26,6 +26,26 @@ service cloud.firestore {
       return hasRole('admin');
     }
 
+    // ── /requests — UC-01 ────────────────────────────────────────────────
+    // Beneficiaries can read the requests they own; the assigned handler can
+    // read theirs; admins can read all. Writes are server-only (Express +
+    // Admin SDK bypass these rules) — the client never writes to /requests.
+    match /requests/{requestId} {
+      allow read: if isSignedIn() && (
+        resource.data.beneficiaryId == request.auth.uid
+        || resource.data.handler == request.auth.uid
+        || isAdmin()
+      );
+      allow create, update, delete: if false;
+    }
+
+    // ── /auditLogs — every server-trusted write is logged ────────────────
+    // Admin-only read; never client-writable.
+    match /auditLogs/{logId} {
+      allow read:  if isAdmin();
+      allow write: if false;
+    }
+
     // Public read of approved catalog entries — open up per-collection as
     // UC-02 / UC-03 land.
     //


### PR DESCRIPTION
## Summary
- **UC-01-c (#27):** Express `POST /api/requests` with zod validation, beneficiary-OR-volunteer role gate, Firestore `.create()` (rejects duplicates as 409), audit log.
- **UC-01-d (#28):** Firestore rules for `/requests/{id}` (signed-in read for owner / handler / admin; client writes denied) + `/auditLogs/{id}` (admin-only read).

Plus: `backend/docs/patterns.md` filled in with the canonical route shape that UC-02..UC-05 owners should copy.

## Endpoint contract

```
POST /api/requests
Headers: Authorization: Bearer <firebase-id-token>
Body: {
  requestId, firstName, lastName, idNumber, phone, email, city,
  age, gender, category, description, urgency, consent,
  attachmentPaths?, onBehalfOf?
}
→ 201 { requestId }
→ 400 { error: 'validation', fieldErrors }
→ 401 { error: 'missing_token' | 'invalid_token' }
→ 403 { error: 'forbidden' }    // not beneficiary or volunteer
→ 409 { error: 'duplicate_request_id' }
```

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run dev` boots; `POST /api/requests` without token → 401
- [x] `firebase deploy --only firestore:rules` compiles + releases cleanly
- [ ] Manual: register a beneficiary, POST a valid body via curl with their ID token → 201 + doc appears in Firestore Console with `status: pending`
- [ ] Manual: same POST twice with the same `requestId` → second returns 409
- [ ] Manual: omit `consent` → 400 validation
- [ ] Manual: Firestore Console — try reading another user's request as the wrong UID → denied

## Notes
- Volunteer-on-behalf (UC-01 alt flow A2) is **schema-supported** here via the optional `onBehalfOf.uid` field — when a volunteer submits with this, `beneficiaryId` is set to the target uid. Full volunteer-dashboard UX is deferred.
- This PR also fills in `backend/docs/patterns.md` (CC-8 prerequisite) with the canonical shape: zod schema at file top, `safeParse`, audit log, error response table, end-to-end curl smoke test.

Closes #27
Closes #28