### PR TITLE
feat(uc-01-b): Storage upload with progress (closes #26)

### DIFF
--- a/frontend/src/components/UploadArea.jsx
+++ b/frontend/src/components/UploadArea.jsx
@@ -1,18 +1,69 @@
-import { useState } from 'react'
-import { Upload, CheckCircle, X, File } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { Upload, CheckCircle, X } from 'lucide-react'
+import { uploadAttachment } from '../lib/storage'
 
-export default function UploadArea({ label, hint, formats, required, onUpload, error }) {
+/**
+ * UploadArea — drag-drop or click-to-pick a single file, upload to Firebase
+ * Storage under `requests/{requestId}/{filename}`, show a progress bar, and
+ * report the resulting Storage path to the parent via `onUpload`.
+ *
+ * Props:
+ *  - label, hint, formats, required, error  — visual labels (same as prototype)
+ *  - requestId  — REQUIRED for real uploads. If null/undefined, the upload is
+ *                 simulated (legacy prototype behavior) so the page is still
+ *                 testable in isolation.
+ *  - onUpload   — called with ({ file, path, downloadURL }) on success, or
+ *                 `null` when the user removes the file. The parent should
+ *                 push `path` into the request's `attachmentPaths[]`.
+ */
+export default function UploadArea({ label, hint, formats, required, onUpload, error, requestId }) {
   const [file, setFile] = useState(null)
   const [uploading, setUploading] = useState(false)
+  const [percent, setPercent] = useState(0)
+  const [errMsg, setErrMsg] = useState('')
+  const handleRef = useRef(null)
 
-  const handleFile = (f) => {
+  // Cancel an in-flight upload if the component unmounts.
+  useEffect(() => () => { if (handleRef.current) handleRef.current.cancel() }, [])
+
+  const handleFile = async (f) => {
     if (!f) return
+    setErrMsg('')
+
+    // No requestId → simulate (keeps Storybook-style isolation working).
+    if (!requestId) {
+      setUploading(true)
+      setTimeout(() => {
+        setUploading(false); setFile(f)
+        if (onUpload) onUpload({ file: f, path: '', downloadURL: '' })
+      }, 600)
+      return
+    }
+
+    // Client-side size guard (matches storage.rules — 10MB).
+    if (f.size > 10 * 1024 * 1024) {
+      setErrMsg('File too large (max 10MB).')
+      return
+    }
+
     setUploading(true)
-    setTimeout(() => {
-      setUploading(false)
+    setPercent(0)
+    try {
+      const handle = uploadAttachment(f, requestId)
+      handleRef.current = handle
+      const unsub = handle.onProgress(setPercent)
+      const result = await handle.done
+      unsub()
+      handleRef.current = null
       setFile(f)
-      if (onUpload) onUpload(f)
-    }, 900)
+      if (onUpload) onUpload({ file: f, path: result.path, downloadURL: result.downloadURL })
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[UploadArea] upload failed:', err)
+      setErrMsg('Upload failed — please try again.')
+    } finally {
+      setUploading(false)
+    }
   }
 
   const handleDrop = (e) => {
@@ -23,7 +74,8 @@ export default function UploadArea({ label, hint, formats, required, onUpload, e
 
   const remove = (e) => {
     e.stopPropagation()
-    setFile(null)
+    if (handleRef.current) { handleRef.current.cancel(); handleRef.current = null }
+    setFile(null); setPercent(0); setErrMsg('')
     if (onUpload) onUpload(null)
   }
 
@@ -61,13 +113,23 @@ export default function UploadArea({ label, hint, formats, required, onUpload, e
         onKeyPress={e => e.key === 'Enter' && document.getElementById(`file-${label}`).click()}
       >
         {uploading ? (
-          <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap:'8px' }}>
+          <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap:'10px', width:'100%' }}>
             <div style={{
               width:'32px', height:'32px', border:'3px solid var(--gray-200)',
               borderTopColor:'var(--navy)', borderRadius:'50%',
               animation:'spin 0.8s linear infinite',
             }} />
-            <span style={{ fontSize:'13.5px', color:'var(--gray-500)' }}>מעלה...</span>
+            <span style={{ fontSize:'13.5px', color:'var(--gray-500)' }}>
+              Uploading… {percent ? `${percent.toFixed(0)}%` : ''}
+            </span>
+            <div style={{ width:'80%', height:6, background:'var(--gray-200)', borderRadius:3, overflow:'hidden' }}>
+              <div style={{
+                width: `${percent.toFixed(0)}%`,
+                height:'100%',
+                background:'var(--navy)',
+                transition:'width 0.15s linear',
+              }} />
+            </div>
           </div>
         ) : (
           <>
@@ -80,9 +142,9 @@ export default function UploadArea({ label, hint, formats, required, onUpload, e
           </>
         )}
       </div>
-      {error && (
+      {(errMsg || error) && (
         <div className="form-error" style={{ marginTop:'6px' }}>
-          <span>{error}</span>
+          <span>{errMsg || error}</span>
         </div>
       )}
       <input

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -1,0 +1,67 @@
+/**
+ * Storage helpers — UC-01-b file uploads.
+ *
+ * Files for a given request live under `requests/{requestId}/{filename}` in
+ * Firebase Storage. The Storage path is also what gets stored in the
+ * request's `attachmentPaths[]` field on the Firestore doc.
+ *
+ * Uploads are resumable so that a flaky connection doesn't lose progress.
+ */
+import {
+  getDownloadURL,
+  ref,
+  uploadBytesResumable,
+  type UploadTask,
+} from 'firebase/storage';
+
+import { firebaseStorage } from './firebase';
+
+export interface UploadHandle {
+  /** Storage path, e.g. `requests/<uuid>/<filename>`. Persist this in Firestore. */
+  path: string;
+  /** A promise resolving to the public download URL once the upload completes. */
+  done: Promise<{ path: string; downloadURL: string }>;
+  /** Subscribe to progress (0–100). Returns an unsubscribe fn. */
+  onProgress: (cb: (percent: number) => void) => () => void;
+  /** Cancel the upload. */
+  cancel: () => void;
+  /** The underlying Firebase upload task (advanced use only). */
+  task: UploadTask;
+}
+
+/** Sanitize a filename so it's safe as a Storage path segment. */
+function safeName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]+/g, '_');
+}
+
+export function uploadAttachment(file: File, requestId: string): UploadHandle {
+  const path = `requests/${requestId}/${safeName(file.name)}`;
+  const storageRef = ref(firebaseStorage, path);
+  const task = uploadBytesResumable(storageRef, file, {
+    contentType: file.type || undefined,
+  });
+
+  const listeners = new Set<(p: number) => void>();
+  task.on('state_changed', (snap) => {
+    const pct = snap.totalBytes ? (snap.bytesTransferred / snap.totalBytes) * 100 : 0;
+    listeners.forEach((cb) => cb(pct));
+  });
+
+  const done = new Promise<{ path: string; downloadURL: string }>((resolve, reject) => {
+    task.then(
+      async () => {
+        const downloadURL = await getDownloadURL(task.snapshot.ref);
+        resolve({ path, downloadURL });
+      },
+      (err) => reject(err),
+    );
+  });
+
+  return {
+    path,
+    done,
+    onProgress: (cb) => { listeners.add(cb); return () => listeners.delete(cb); },
+    cancel: () => task.cancel(),
+    task,
+  };
+}

--- a/frontend/src/screens/RequestsPage.jsx
+++ b/frontend/src/screens/RequestsPage.jsx
@@ -38,6 +38,10 @@ export default function RequestsPage() {
   const [submitted, setSubmitted] = useState(false)
   const [idUploaded, setIdUploaded] = useState(false)
   const [supportUploaded, setSupportUploaded] = useState(false)
+  // Storage paths of uploaded files (UC-01-b). Built up as files complete;
+  // sent to POST /api/requests as `attachmentPaths`.
+  const [idPath, setIdPath] = useState('')
+  const [supportPath, setSupportPath] = useState('')
   const [submitting, setSubmitting] = useState(false)
 
   // requestId is generated once per form session. Used as the Firestore doc id
@@ -95,7 +99,8 @@ export default function RequestsPage() {
         description: values.description,
         urgency:   values.urgency,
         consent:   values.consent === true,
-        attachmentPaths: [], // wired in UC-01-b (PR D)
+        // Storage paths of uploaded attachments (UC-01-b).
+        attachmentPaths: [idPath, supportPath].filter(Boolean),
       }
       const res = await apiFetch('/api/requests', {
         method: 'POST',
@@ -319,7 +324,11 @@ export default function RequestsPage() {
                 hint={rq.step3.idHint}
                 formats={rq.step3.idFormats}
                 required
-                onUpload={f => setIdUploaded(!!f)}
+                requestId={requestId}
+                onUpload={(r) => {
+                  setIdUploaded(!!r)
+                  setIdPath(r?.path || '')
+                }}
                 error={errors.idDoc}
               />
             </FormGroup>
@@ -328,7 +337,11 @@ export default function RequestsPage() {
                 label={rq.step3.supportLabel}
                 hint={rq.step3.supportHint}
                 formats={rq.step3.supportFormats}
-                onUpload={f => setSupportUploaded(!!f)}
+                requestId={requestId}
+                onUpload={(r) => {
+                  setSupportUploaded(!!r)
+                  setSupportPath(r?.path || '')
+                }}
               />
             </FormGroup>
             <div style={{

--- a/storage.rules
+++ b/storage.rules
@@ -1,27 +1,41 @@
-// Firebase Storage Security Rules — initial deny-all template.
+// Firebase Storage Security Rules.
 //
-// As UC-01 lands, we'll allow signed-in users to upload to
-// `requests/{requestId}/{filename}` with size + MIME limits.
+// UC-01-b: any signed-in user may upload to `requests/{requestId}/{filename}`
+// subject to size (≤10MB) and MIME (PDF / JPEG / PNG / DOCX) limits. Reads
+// require either ownership of the matching Firestore request doc or the
+// admin role custom claim.
 
 rules_version = '2';
 
 service firebase.storage {
   match /b/{bucket}/o {
 
-    // Catch-all: deny.
+    // ── /requests/{requestId}/{filename} — UC-01 attachments ──────────
+    match /requests/{requestId}/{filename} {
+      // Read: must be signed in, and either own the matching request doc
+      // or be an admin. The request doc lookup uses the Firestore-bridge
+      // function available in Storage rules.
+      allow read: if request.auth != null
+                  && (
+                       firestore.get(/databases/(default)/documents/requests/$(requestId)).data.beneficiaryId == request.auth.uid
+                       || request.auth.token.role == 'admin'
+                     );
+
+      // Write: signed-in users with size + MIME limits. The Firestore
+      // request doc may not exist yet at upload time (we upload before
+      // POST /api/requests creates it), so we cannot gate writes on doc
+      // ownership. The collision risk is negligible because requestId is
+      // a v4 UUID generated client-side.
+      allow write: if request.auth != null
+                   && request.resource.size < 10 * 1024 * 1024
+                   && request.resource.contentType.matches(
+                        'application/pdf|image/(jpeg|png)|application/(msword|vnd.openxmlformats-officedocument.wordprocessingml.document)'
+                      );
+    }
+
+    // Catch-all: deny everything not explicitly allowed above.
     match /{allPaths=**} {
       allow read, write: if false;
     }
-
-    // Example to add when UC-01 lands (commented out for now):
-    //
-    // match /requests/{requestId}/{filename} {
-    //   allow read:  if request.auth != null;
-    //   allow write: if request.auth != null
-    //                && request.resource.size < 10 * 1024 * 1024
-    //                && request.resource.contentType.matches(
-    //                     'application/pdf|image/(jpeg|png)|application/(msword|vnd.openxmlformats-officedocument.wordprocessingml.document)'
-    //                   );
-    // }
   }
 }


### PR DESCRIPTION
## Summary
Real attachment uploads to Firebase Storage with a live progress bar. Replaces the prototype's `setTimeout` fake.

## Changes
**Frontend:**
- `src/lib/storage.ts` — `uploadAttachment(file, requestId)` returns `{ path, done, onProgress, cancel, task }` over Firebase's resumable upload
- `components/UploadArea.jsx` — wires the real upload, shows percentage + progress bar, cancels in-flight uploads on unmount/remove, 10MB client guard
- `screens/RequestsPage.jsx` — passes `requestId` into both UploadAreas; collects `idPath` + `supportPath` and ships them as `attachmentPaths[]` in the POST body

**Storage rules:**
```
match /requests/{requestId}/{filename} {
  allow read:  if signed-in AND (owner of request doc OR admin)
  allow write: if signed-in AND size < 10MB AND MIME ∈ {pdf, jpeg, png, docx}
}
```
Deployed cleanly to `push-for-fulfillment-staging`.

## Test plan
- [x] `npm run build` clean
- [x] `firebase deploy --only storage` compiled + released
- [ ] Manual: pick a 2MB PDF in step 3 → progress bar fills → file lands at `requests/<uuid>/foo.pdf` in Storage Console
- [ ] Manual: pick a 15MB file → client-side error "File too large (max 10MB)" (rule would also reject)
- [ ] Manual: pick a `.exe` → rejected at upload time by the MIME rule (Storage 403)
- [ ] Manual: submit the form → Firestore doc has `attachmentPaths: ["requests/<uuid>/...pdf", ...]`
- [ ] Manual: sign in as a different user → try reading the file URL → denied

## Design note — write rule
The request Firestore doc doesn't exist yet at upload time (we upload before `POST /api/requests`). The write rule therefore can't gate on doc ownership — it's "signed-in + size + MIME" only. Collision risk is negligible because `requestId` is a v4 UUID generated client-side, and a hostile user spamming someone else's bucket prefix would still need to guess the UUID.

Closes #26