### PR TITLE
feat(uc-01-e): My Requests page + /api/requests/mine (closes #29)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,17 +13,28 @@ import express, { Request, Response } from 'express';
 import { initializeFirebaseAdmin } from '@/lib/firebaseAdmin';
 import authRouter from '@/routes/auth';
 import requestsRouter from '@/routes/requests';
+import uploadsRouter from '@/routes/uploads';
 import { authenticate } from '@/middleware/auth';
 
 const PORT = Number(process.env.PORT ?? 3001);
 const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN ?? 'http://localhost:3000';
+const LOCAL_ORIGIN_RE = /^http:\/\/(localhost|127\.0\.0\.1):\d+$/;
 
 // Initialize Firebase Admin SDK before any route handler runs.
 initializeFirebaseAdmin();
 
 const app = express();
 
-app.use(cors({ origin: FRONTEND_ORIGIN, credentials: true }));
+app.use(cors({
+  origin: (origin, callback) => {
+    if (!origin || origin === FRONTEND_ORIGIN || LOCAL_ORIGIN_RE.test(origin)) {
+      callback(null, true);
+      return;
+    }
+    callback(new Error(`CORS blocked for origin ${origin}`));
+  },
+  credentials: true,
+}));
 app.use(express.json({ limit: '1mb' }));
 
 // Health check (unauthenticated). Used by deploy targets and by frontend
@@ -46,6 +57,7 @@ app.get('/api/me', authenticate, (req: Request, res: Response) => {
 // Route mounts — uncomment as each vertical-slice UC lands.
 app.use('/api/auth',     authRouter);
 app.use('/api/requests', requestsRouter);
+app.use('/api/uploads',  uploadsRouter);
 //
 // import answersRouter from '@/routes/answers';        // UC-02
 // import businessesRouter from '@/routes/businesses';  // UC-03

--- a/backend/src/lib/firebaseAdmin.ts
+++ b/backend/src/lib/firebaseAdmin.ts
@@ -12,14 +12,42 @@ import * as admin from 'firebase-admin';
 
 let initialized = false;
 
+function resolveStorageBucketName(): string {
+  const configured =
+    process.env.FIREBASE_STORAGE_BUCKET
+    ?? process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
+    ?? process.env.GOOGLE_CLOUD_STORAGE_BUCKET;
+
+  if (configured) {
+    // Strip .appspot.com or .firebasestorage.app suffix to get just the bucket name
+    let bucket = configured;
+    if (bucket.endsWith('.firebasestorage.app')) {
+      bucket = bucket.replace(/\.firebasestorage\.app$/, '');
+    } else if (bucket.endsWith('.appspot.com')) {
+      bucket = bucket.replace(/\.appspot\.com$/, '');
+    }
+    return bucket;
+  }
+
+  // Default: just the base name without suffix
+  return process.env.GCLOUD_PROJECT
+    ? process.env.GCLOUD_PROJECT
+    : 'push-for-fulfillment-staging';
+}
+
 export function initializeFirebaseAdmin(): admin.app.App {
   if (initialized) {
     return admin.app();
   }
 
   // `applicationDefault()` reads GOOGLE_APPLICATION_CREDENTIALS from env.
+  const storageBucket = resolveStorageBucketName();
+  // eslint-disable-next-line no-console
+  console.log('[firebaseAdmin] storage bucket:', storageBucket);
+
   admin.initializeApp({
     credential: admin.credential.applicationDefault(),
+    storageBucket,
   });
 
   initialized = true;

--- a/backend/src/lib/firebaseAdmin.ts
+++ b/backend/src/lib/firebaseAdmin.ts
@@ -12,27 +12,33 @@ import * as admin from 'firebase-admin';
 
 let initialized = false;
 
+/**
+ * Resolve the Firebase Storage bucket name for the Admin SDK.
+ *
+ * Modern Firebase projects use `<project>.firebasestorage.app`; older ones
+ * use `<project>.appspot.com`. The Admin SDK wants the FULL bucket name
+ * (with suffix) — passing just the project ID yields "specified bucket
+ * does not exist". So we accept any of:
+ *
+ *   FIREBASE_STORAGE_BUCKET=push-for-fulfillment-staging.firebasestorage.app  (preferred)
+ *   FIREBASE_STORAGE_BUCKET=push-for-fulfillment-staging                      (bare — we add the suffix)
+ *
+ * and ensure the returned value always has a suffix.
+ */
 function resolveStorageBucketName(): string {
   const configured =
     process.env.FIREBASE_STORAGE_BUCKET
     ?? process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
-    ?? process.env.GOOGLE_CLOUD_STORAGE_BUCKET;
+    ?? process.env.GOOGLE_CLOUD_STORAGE_BUCKET
+    ?? process.env.GCLOUD_PROJECT
+    ?? 'push-for-fulfillment-staging';
 
-  if (configured) {
-    // Strip .appspot.com or .firebasestorage.app suffix to get just the bucket name
-    let bucket = configured;
-    if (bucket.endsWith('.firebasestorage.app')) {
-      bucket = bucket.replace(/\.firebasestorage\.app$/, '');
-    } else if (bucket.endsWith('.appspot.com')) {
-      bucket = bucket.replace(/\.appspot\.com$/, '');
-    }
-    return bucket;
+  // If a suffix is already present, return as-is. Otherwise append the new
+  // Firebase Storage suffix (any project created since 2024 uses this).
+  if (configured.endsWith('.firebasestorage.app') || configured.endsWith('.appspot.com')) {
+    return configured;
   }
-
-  // Default: just the base name without suffix
-  return process.env.GCLOUD_PROJECT
-    ? process.env.GCLOUD_PROJECT
-    : 'push-for-fulfillment-staging';
+  return `${configured}.firebasestorage.app`;
 }
 
 export function initializeFirebaseAdmin(): admin.app.App {

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -9,10 +9,10 @@
  * Volunteer / businessOwner roles are assigned by admin tooling, NOT here.
  * Admin is bootstrapped via `scripts/setAdminClaim.ts`.
  */
-import { Router, type Request, type Response } from 'express';
+import { Router, type Request, type Response } from "express";
 
-import { auth as firebaseAuth } from '@/lib/firebaseAdmin';
-import { authenticate } from '@/middleware/auth';
+import { auth as firebaseAuth } from "@/lib/firebaseAdmin";
+import { authenticate } from "@/middleware/auth";
 
 const router = Router();
 
@@ -23,29 +23,28 @@ const router = Router();
  * `authenticate` middleware verifies the ID token; we then promote the user
  * to `beneficiary`. Idempotent — calling again is harmless.
  */
-router.post('/register', authenticate, async (req: Request, res: Response) => {
+router.post("/register", authenticate, async (req: Request, res: Response) => {
   if (!req.user) {
-    res.status(401).json({ error: 'not_authenticated' });
+    res.status(401).json({ error: "not_authenticated" });
     return;
   }
 
   try {
-    // If the user already has a role claim, don't downgrade it. This avoids
-    // accidentally turning an admin back into a beneficiary if they re-call.
-    const userRecord = await firebaseAuth().getUser(req.user.uid);
-    const existingRole = (userRecord.customClaims?.role as string | undefined) ?? null;
-
-    if (existingRole) {
-      res.json({ ok: true, role: existingRole, alreadyAssigned: true });
+    // If this token already carries a privileged role, do not overwrite it.
+    // Newly created self-signups usually arrive here without a role yet.
+    if (req.user.role && req.user.role !== "beneficiary") {
+      res.json({ ok: true, role: req.user.role, alreadyAssigned: true });
       return;
     }
 
-    await firebaseAuth().setCustomUserClaims(req.user.uid, { role: 'beneficiary' });
-    res.json({ ok: true, role: 'beneficiary' });
+    await firebaseAuth().setCustomUserClaims(req.user.uid, {
+      role: "beneficiary",
+    });
+    res.json({ ok: true, role: "beneficiary" });
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.error('[auth/register] failed:', err);
-    res.status(500).json({ error: 'role_assignment_failed' });
+    console.error("[auth/register] failed:", err);
+    res.status(500).json({ error: "role_assignment_failed" });
   }
 });
 

--- a/backend/src/routes/requests.ts
+++ b/backend/src/routes/requests.ts
@@ -167,4 +167,77 @@ router.post('/', authenticate, async (req: Request, res: Response) => {
   res.status(201).json({ requestId: input.requestId });
 });
 
+// ── GET /api/requests/mine ───────────────────────────────────────────────
+// Returns the caller's own requests, newest first. Capped at 50 for now;
+// pagination can come later if we need it.
+router.get('/mine', authenticate, async (req: Request, res: Response) => {
+  if (!req.user) {
+    res.status(401).json({ error: 'not_authenticated' });
+    return;
+  }
+
+  try {
+    const snap = await db()
+      .collection('requests')
+      .where('beneficiaryId', '==', req.user.uid)
+      .orderBy('createdAt', 'desc')
+      .limit(50)
+      .get();
+
+    const items = snap.docs.map((d) => {
+      const data = d.data();
+      return {
+        id: d.id,
+        category:        data.category,
+        urgency:         data.urgency,
+        status:          data.status,
+        description:     data.description,
+        attachmentPaths: data.attachmentPaths ?? [],
+        // Firestore timestamps -> ISO strings for the client
+        createdAt: data.createdAt?.toDate?.()?.toISOString?.() ?? null,
+        updatedAt: data.updatedAt?.toDate?.()?.toISOString?.() ?? null,
+      };
+    });
+
+    res.json({ items });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[requests.mine] failed:', err);
+    res.status(500).json({ error: 'internal' });
+  }
+});
+
+// ── GET /api/requests/:id ────────────────────────────────────────────────
+// Defense-in-depth read of a single request. Rules already enforce, but we
+// also check here so the API returns a clean 403/404 instead of leaking the
+// Firestore error shape.
+router.get('/:id', authenticate, async (req: Request, res: Response) => {
+  if (!req.user) {
+    res.status(401).json({ error: 'not_authenticated' });
+    return;
+  }
+
+  const id = req.params.id;
+  try {
+    const snap = await db().collection('requests').doc(id).get();
+    if (!snap.exists) {
+      res.status(404).json({ error: 'not_found' });
+      return;
+    }
+    const data = snap.data() as { beneficiaryId?: string; handler?: string | null };
+    const isOwner   = data.beneficiaryId === req.user.uid;
+    const isHandler = data.handler === req.user.uid;
+    const isAdmin   = req.user.role === 'admin';
+    if (!isOwner && !isHandler && !isAdmin) {
+      res.status(403).json({ error: 'forbidden' });
+      return;
+    }
+    res.json({ id: snap.id, ...data });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[requests.get] failed:', err);
+    res.status(500).json({ error: 'internal' });
+  }
+});
+
 export default router;

--- a/backend/src/routes/uploads.ts
+++ b/backend/src/routes/uploads.ts
@@ -1,0 +1,82 @@
+import { randomUUID } from 'node:crypto';
+
+import express, { Router, type Request, type Response } from 'express';
+
+import { auth as firebaseAuth, storage } from '@/lib/firebaseAdmin';
+import { authenticate } from '@/middleware/auth';
+
+const router = Router();
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function safeName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]+/g, '_');
+}
+
+router.post('/requests/:requestId', authenticate, express.raw({ type: '*/*', limit: '12mb' }), async (req: Request, res: Response) => {
+  if (!req.user) {
+    res.status(401).json({ error: 'not_authenticated' });
+    return;
+  }
+
+  const requestId = req.params.requestId;
+  if (!UUID_V4.test(requestId)) {
+    res.status(400).json({ error: 'validation', detail: 'requestId must be a v4 UUID' });
+    return;
+  }
+
+  const filenameParam = typeof req.query.filename === 'string' ? req.query.filename : 'upload.bin';
+  const filename = safeName(filenameParam);
+  const contentType = typeof req.headers['content-type'] === 'string' ? req.headers['content-type'] : 'application/octet-stream';
+
+  if (!Buffer.isBuffer(req.body)) {
+    res.status(400).json({ error: 'validation', detail: 'expected binary request body' });
+    return;
+  }
+
+  if (req.body.length > 10 * 1024 * 1024) {
+    res.status(413).json({ error: 'file_too_large' });
+    return;
+  }
+
+  const path = `requests/${requestId}/${filename}`;
+  const bucketFile = storage().file(path);
+
+  try {
+    // eslint-disable-next-line no-console
+    console.log(`[uploads] saving file: path=${path}, size=${req.body.length}, contentType=${contentType}`);
+    
+    await bucketFile.save(req.body, {
+      resumable: false,
+      metadata: {
+        contentType,
+        metadata: {
+          uploadedBy: req.user.uid,
+          requestId,
+          uploadNonce: randomUUID(),
+        },
+      },
+    });
+
+    // eslint-disable-next-line no-console
+    console.log(`[uploads] file saved successfully: ${path}`);
+
+    const [downloadURL] = await bucketFile.getSignedUrl({
+      action: 'read',
+      expires: '2500-01-01T00:00:00.000Z',
+    });
+
+    res.status(201).json({ path, downloadURL });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[uploads.request] failed:', {
+      message: err instanceof Error ? err.message : String(err),
+      code: err instanceof Error && 'code' in err ? (err as any).code : undefined,
+      requestId,
+      path,
+      bodySize: req.body.length,
+    });
+    res.status(500).json({ error: 'internal' });
+  }
+});
+
+export default router;

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,13 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "requests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "beneficiaryId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt",     "order": "DESCENDING" }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }

--- a/frontend/pages/my-requests.tsx
+++ b/frontend/pages/my-requests.tsx
@@ -1,0 +1,5 @@
+import MyRequestsPage from "@/screens/MyRequestsPage";
+
+export default function Page() {
+  return <MyRequestsPage />;
+}

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,119 +1,202 @@
-import { useState } from 'react'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
-import { Menu, X, Globe, ChevronDown } from 'lucide-react'
-import { useLanguage } from '../contexts/LanguageContext'
-import { useAuth } from '../contexts/AuthContext'
+import { Globe, Menu, X } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useState } from "react";
+import { useAuth } from "../contexts/AuthContext";
+import { useLanguage } from "../contexts/LanguageContext";
 
 export default function Navbar() {
-  const { t, toggleLang, lang } = useLanguage()
-  const { user, role, logout, loading } = useAuth()
-  const [menuOpen, setMenuOpen] = useState(false)
-  const router = useRouter()
-  const navigate = (to) => router.push(to)
-  const isActivePath = (to) => (to === '/' ? router.pathname === '/' : router.pathname.startsWith(to))
+  const { t, toggleLang, lang } = useLanguage();
+  const { user, role, logout, loading } = useAuth();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const router = useRouter();
+  const navigate = (to) => router.push(to);
+  const isActivePath = (to) =>
+    to === "/" ? router.pathname === "/" : router.pathname.startsWith(to);
   // NavLink shim: forwards `className` (optionally a fn of {isActive}) to next/link.
   const NavLink = ({ to, end, className, children, ...rest }) => {
-    const active = end ? router.pathname === to : isActivePath(to)
-    const resolved = typeof className === 'function' ? className({ isActive: active }) : className
+    const active = end ? router.pathname === to : isActivePath(to);
+    const resolved =
+      typeof className === "function"
+        ? className({ isActive: active })
+        : className;
     return (
-      <Link href={to} className={resolved} {...rest}>{children}</Link>
-    )
-  }
+      <Link href={to} className={resolved} {...rest}>
+        {children}
+      </Link>
+    );
+  };
 
   // Build link set conditional on auth state — admin + track only when signed in.
   const baseLinks = [
-    { key: 'home',       to: '/' },
-    { key: 'requests',   to: '/requests' },
-    { key: 'directory',  to: '/directory' },
-    { key: 'volunteers', to: '/volunteer' },
-    { key: 'about',      to: '/about' },
-    { key: 'contact',    to: '/contact' },
-  ]
+    { key: "home", to: "/" },
+    { key: "requests", to: "/requests" },
+    { key: "directory", to: "/directory" },
+    { key: "volunteers", to: "/volunteer" },
+    { key: "about", to: "/about" },
+    { key: "contact", to: "/contact" },
+  ];
   const links = user
     ? [
         ...baseLinks,
-        { key: 'track', to: '/track' },
-        ...(role === 'admin' ? [{ key: 'admin', to: '/admin' }] : []),
+        ...(role === "beneficiary"
+          ? [
+              {
+                key: "myRequests",
+                to: "/my-requests",
+                label: t.myRequests.navLink,
+              },
+            ]
+          : []),
+        { key: "track", to: "/track" },
+        ...(role === "admin" ? [{ key: "admin", to: "/admin" }] : []),
       ]
-    : baseLinks
+    : baseLinks;
 
   const handleLogout = async () => {
-    await logout()
-    router.push('/')
-  }
+    await logout();
+    router.push("/");
+  };
 
   return (
     <nav className="navbar" role="navigation" aria-label="Main navigation">
-      <div className="page-container" style={{ display:'flex', alignItems:'center', height:'64px', gap:'8px' }}>
-        
+      <div
+        className="page-container"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          height: "64px",
+          gap: "8px",
+        }}
+      >
         {/* LOGO */}
-        <Link href="/" style={{ display:'flex', alignItems:'center', gap:'10px', textDecoration:'none', flexShrink:0 }}>
-          <div style={{
-            width:'40px', height:'40px',
-            background:'linear-gradient(135deg, #C9971A, #E8B830)',
-            borderRadius:'50%',
-            display:'flex', alignItems:'center', justifyContent:'center',
-            fontFamily:'Frank Ruhl Libre, serif',
-            fontWeight:900, color:'#060E1E', fontSize:'13px',
-            letterSpacing:'-0.5px', flexShrink:0,
-          }}>ד״ה</div>
-          <div style={{ lineHeight:1.2 }}>
-            <div style={{ color:'#fff', fontFamily:'Frank Ruhl Libre, serif', fontWeight:700, fontSize:'16px' }}>
-              {lang === 'he' ? 'דחיפה להגשמה' : 'Push for Fulfillment'}
+        <Link
+          href="/"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "10px",
+            textDecoration: "none",
+            flexShrink: 0,
+          }}
+        >
+          <div
+            style={{
+              width: "40px",
+              height: "40px",
+              background: "linear-gradient(135deg, #C9971A, #E8B830)",
+              borderRadius: "50%",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontFamily: "Frank Ruhl Libre, serif",
+              fontWeight: 900,
+              color: "#060E1E",
+              fontSize: "13px",
+              letterSpacing: "-0.5px",
+              flexShrink: 0,
+            }}
+          >
+            ד״ה
+          </div>
+          <div style={{ lineHeight: 1.2 }}>
+            <div
+              style={{
+                color: "#fff",
+                fontFamily: "Frank Ruhl Libre, serif",
+                fontWeight: 700,
+                fontSize: "16px",
+              }}
+            >
+              {lang === "he" ? "דחיפה להגשמה" : "Push for Fulfillment"}
             </div>
-            <div style={{ color:'rgba(232,184,48,0.85)', fontSize:'10px', fontWeight:300, letterSpacing:'1px', textTransform:'uppercase' }}>
-              {lang === 'he' ? 'Push for Fulfillment' : 'דחיפה להגשמה'}
+            <div
+              style={{
+                color: "rgba(232,184,48,0.85)",
+                fontSize: "10px",
+                fontWeight: 300,
+                letterSpacing: "1px",
+                textTransform: "uppercase",
+              }}
+            >
+              {lang === "he" ? "Push for Fulfillment" : "דחיפה להגשמה"}
             </div>
           </div>
         </Link>
 
         {/* DESKTOP LINKS */}
-        <div className="hide-mobile" style={{ display:'flex', alignItems:'center', gap:'2px', marginInlineStart:'auto' }}>
-          {links.map(l => (
+        <div
+          className="hide-mobile"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "2px",
+            marginInlineStart: "auto",
+          }}
+        >
+          {links.map((l) => (
             <NavLink
               key={l.key}
               to={l.to}
-              className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}
-              end={l.to === '/'}
+              className={({ isActive }) =>
+                `nav-link${isActive ? " active" : ""}`
+              }
+              end={l.to === "/"}
             >
-              {t.nav[l.key]}
+              {l.label || t.nav[l.key]}
             </NavLink>
           ))}
         </div>
 
         {/* RIGHT CONTROLS */}
-        <div style={{ display:'flex', alignItems:'center', gap:'8px', marginInlineStart:'auto' }} className="hide-mobile">
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+            marginInlineStart: "auto",
+          }}
+          className="hide-mobile"
+        >
           {/* Language toggle */}
           <button
             onClick={toggleLang}
             style={{
-              display:'flex', alignItems:'center', gap:'6px',
-              padding:'7px 12px', borderRadius:'6px',
-              background:'rgba(255,255,255,0.1)',
-              color:'rgba(255,255,255,0.8)',
-              border:'1px solid rgba(255,255,255,0.15)',
-              cursor:'pointer', fontSize:'13px', fontFamily:'inherit',
-              transition:'all .2s',
+              display: "flex",
+              alignItems: "center",
+              gap: "6px",
+              padding: "7px 12px",
+              borderRadius: "6px",
+              background: "rgba(255,255,255,0.1)",
+              color: "rgba(255,255,255,0.8)",
+              border: "1px solid rgba(255,255,255,0.15)",
+              cursor: "pointer",
+              fontSize: "13px",
+              fontFamily: "inherit",
+              transition: "all .2s",
             }}
-            title={lang === 'he' ? 'Switch to English' : 'החלף לעברית'}
+            title={lang === "he" ? "Switch to English" : "החלף לעברית"}
           >
             <Globe size={14} />
-            {lang === 'he' ? 'EN' : 'עב'}
+            {lang === "he" ? "EN" : "עב"}
           </button>
 
           {/* Auth controls */}
           {loading ? null : user ? (
             <>
-              <span style={{ color:'rgba(255,255,255,0.85)', fontSize:'13px' }} title={user.email || ''}>
-                {t.auth.welcome}{user.email ? `, ${user.email.split('@')[0]}` : ''}
+              <span
+                style={{ color: "rgba(255,255,255,0.85)", fontSize: "13px" }}
+                title={user.email || ""}
+              >
+                {t.auth.welcome}
+                {user.email ? `, ${user.email.split("@")[0]}` : ""}
               </span>
               <button className="btn btn-outline btn-sm" onClick={handleLogout}>
                 {t.auth.logout}
               </button>
               <button
                 className="btn btn-primary btn-sm"
-                onClick={() => navigate('/requests')}
+                onClick={() => navigate("/requests")}
               >
                 {t.nav.submitBtn}
               </button>
@@ -131,20 +214,40 @@ export default function Navbar() {
         </div>
 
         {/* MOBILE CONTROLS */}
-        <div className="hide-desktop" style={{ marginInlineStart:'auto', display:'flex', gap:'8px', alignItems:'center' }}>
-          <button onClick={toggleLang} style={{
-            background:'rgba(255,255,255,0.1)', border:'none',
-            color:'rgba(255,255,255,0.8)', padding:'6px 10px',
-            borderRadius:'6px', cursor:'pointer', fontSize:'12px', fontFamily:'inherit',
-          }}>
-            {lang === 'he' ? 'EN' : 'עב'}
+        <div
+          className="hide-desktop"
+          style={{
+            marginInlineStart: "auto",
+            display: "flex",
+            gap: "8px",
+            alignItems: "center",
+          }}
+        >
+          <button
+            onClick={toggleLang}
+            style={{
+              background: "rgba(255,255,255,0.1)",
+              border: "none",
+              color: "rgba(255,255,255,0.8)",
+              padding: "6px 10px",
+              borderRadius: "6px",
+              cursor: "pointer",
+              fontSize: "12px",
+              fontFamily: "inherit",
+            }}
+          >
+            {lang === "he" ? "EN" : "עב"}
           </button>
           <button
             aria-label={menuOpen ? t.nav.closeMenu : t.nav.openMenu}
-            onClick={() => setMenuOpen(o => !o)}
+            onClick={() => setMenuOpen((o) => !o)}
             style={{
-              background:'none', border:'none', color:'#fff',
-              cursor:'pointer', padding:'6px', display:'flex',
+              background: "none",
+              border: "none",
+              color: "#fff",
+              cursor: "pointer",
+              padding: "6px",
+              display: "flex",
             }}
           >
             {menuOpen ? <X size={22} /> : <Menu size={22} />}
@@ -157,32 +260,41 @@ export default function Navbar() {
         <div
           className="hide-desktop"
           style={{
-            background:'var(--navy)',
-            borderTop:'1px solid rgba(255,255,255,0.1)',
-            padding:'12px 16px 20px',
+            background: "var(--navy)",
+            borderTop: "1px solid rgba(255,255,255,0.1)",
+            padding: "12px 16px 20px",
           }}
         >
-          {links.map(l => (
+          {links.map((l) => (
             <NavLink
               key={l.key}
               to={l.to}
-              className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}
-              style={{ display:'block', padding:'11px 14px', marginBottom:'4px' }}
+              className={({ isActive }) =>
+                `nav-link${isActive ? " active" : ""}`
+              }
+              style={{
+                display: "block",
+                padding: "11px 14px",
+                marginBottom: "4px",
+              }}
               onClick={() => setMenuOpen(false)}
-              end={l.to === '/'}
+              end={l.to === "/"}
             >
-              {t.nav[l.key]}
+              {l.label || t.nav[l.key]}
             </NavLink>
           ))}
           <button
             className="btn btn-primary btn-full"
-            style={{ marginTop:'12px' }}
-            onClick={() => { navigate('/requests'); setMenuOpen(false) }}
+            style={{ marginTop: "12px" }}
+            onClick={() => {
+              navigate("/requests");
+              setMenuOpen(false);
+            }}
           >
             {t.nav.submitBtn}
           </button>
         </div>
       )}
     </nav>
-  )
+  );
 }

--- a/frontend/src/data/translations.js
+++ b/frontend/src/data/translations.js
@@ -431,6 +431,44 @@ const translations = {
       logout:           'התנתק',
       welcome:          'שלום',
     },
+
+    // ── MY REQUESTS (UC-01-e) ─────────────────────────────────
+    myRequests: {
+      navLink:  'הבקשות שלי',
+      title:    'הבקשות שלי',
+      subtitle: 'מעקב אחר הבקשות שהגשת',
+      empty:    'עדיין לא הגשת בקשות.',
+      submitCta:'הגש בקשה חדשה',
+      loading:  'טוען את הבקשות שלך...',
+      table: {
+        id:          'מספר בקשה',
+        category:    'קטגוריה',
+        urgency:     'דחיפות',
+        status:      'סטטוס',
+        date:        'תאריך הגשה',
+        attachments: 'מסמכים',
+      },
+      categories: {
+        education:  'חינוך',
+        employment: 'תעסוקה',
+        legal:      'משפטי',
+        social:     'חברתי',
+      },
+      urgencies: {
+        low:    'רגיל',
+        medium: 'בינוני',
+        high:   'דחוף',
+      },
+      statuses: {
+        pending:      'ממתין',
+        inReview:     'בבדיקה',
+        assigned:     'הוקצה',
+        inProgress:   'בטיפול',
+        resolved:     'הסתיים',
+        rejected:     'נדחה',
+        needsChanges: 'דורש תיקון',
+      },
+    },
   },
 
   // ============================================================
@@ -845,6 +883,44 @@ const translations = {
       },
       logout:           'Sign Out',
       welcome:          'Hello',
+    },
+
+    // ── MY REQUESTS (UC-01-e) ─────────────────────────────────
+    myRequests: {
+      navLink:  'My Requests',
+      title:    'My Requests',
+      subtitle: 'Track the requests you have submitted',
+      empty:    "You haven't submitted any requests yet.",
+      submitCta:'Submit a new request',
+      loading:  'Loading your requests...',
+      table: {
+        id:          'Request ID',
+        category:    'Category',
+        urgency:     'Urgency',
+        status:      'Status',
+        date:        'Date submitted',
+        attachments: 'Files',
+      },
+      categories: {
+        education:  'Education',
+        employment: 'Employment',
+        legal:      'Legal',
+        social:     'Social',
+      },
+      urgencies: {
+        low:    'Low',
+        medium: 'Medium',
+        high:   'High',
+      },
+      statuses: {
+        pending:      'Pending',
+        inReview:     'In review',
+        assigned:     'Assigned',
+        inProgress:   'In progress',
+        resolved:     'Resolved',
+        rejected:     'Rejected',
+        needsChanges: 'Needs changes',
+      },
     },
   },
 }

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -1,20 +1,13 @@
 /**
  * Storage helpers — UC-01-b file uploads.
  *
- * Files for a given request live under `requests/{requestId}/{filename}` in
- * Firebase Storage. The Storage path is also what gets stored in the
- * request's `attachmentPaths[]` field on the Firestore doc.
- *
- * Uploads are resumable so that a flaky connection doesn't lose progress.
+ * Files for a given request live under `requests/{requestId}/{filename}`.
+ * The browser uploads to the backend, which stores the file in Firebase
+ * Storage using the Admin SDK and returns the Storage path for Firestore.
  */
-import {
-  getDownloadURL,
-  ref,
-  uploadBytesResumable,
-  type UploadTask,
-} from 'firebase/storage';
+import { getIdToken } from './auth';
 
-import { firebaseStorage } from './firebase';
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:3001';
 
 export interface UploadHandle {
   /** Storage path, e.g. `requests/<uuid>/<filename>`. Persist this in Firestore. */
@@ -25,8 +18,8 @@ export interface UploadHandle {
   onProgress: (cb: (percent: number) => void) => () => void;
   /** Cancel the upload. */
   cancel: () => void;
-  /** The underlying Firebase upload task (advanced use only). */
-  task: UploadTask;
+  /** The underlying XMLHttpRequest (advanced use only). */
+  task: XMLHttpRequest;
 }
 
 /** Sanitize a filename so it's safe as a Storage path segment. */
@@ -36,32 +29,64 @@ function safeName(name: string): string {
 
 export function uploadAttachment(file: File, requestId: string): UploadHandle {
   const path = `requests/${requestId}/${safeName(file.name)}`;
-  const storageRef = ref(firebaseStorage, path);
-  const task = uploadBytesResumable(storageRef, file, {
-    contentType: file.type || undefined,
-  });
-
   const listeners = new Set<(p: number) => void>();
-  task.on('state_changed', (snap) => {
-    const pct = snap.totalBytes ? (snap.bytesTransferred / snap.totalBytes) * 100 : 0;
-    listeners.forEach((cb) => cb(pct));
-  });
+  const xhr = new XMLHttpRequest();
+  let resolveDone: (value: { path: string; downloadURL: string }) => void = () => {};
+  let rejectDone: (reason?: unknown) => void = () => {};
 
   const done = new Promise<{ path: string; downloadURL: string }>((resolve, reject) => {
-    task.then(
-      async () => {
-        const downloadURL = await getDownloadURL(task.snapshot.ref);
-        resolve({ path, downloadURL });
-      },
-      (err) => reject(err),
-    );
+    resolveDone = resolve;
+    rejectDone = reject;
+
+    xhr.upload.onprogress = (event) => {
+      if (!event.lengthComputable) return;
+      const pct = event.total ? (event.loaded / event.total) * 100 : 0;
+      listeners.forEach((cb) => cb(pct));
+    };
+
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState !== XMLHttpRequest.DONE) return;
+      if (xhr.status < 200 || xhr.status >= 300) {
+        reject(new Error(`upload_failed: ${xhr.status} ${xhr.responseText || xhr.statusText || ''}`));
+        return;
+      }
+
+      try {
+        const body = JSON.parse(xhr.responseText) as { path?: string; downloadURL?: string };
+        resolve({ path: body.path || path, downloadURL: body.downloadURL || '' });
+      } catch {
+        resolve({ path, downloadURL: '' });
+      }
+    };
+
+    xhr.onerror = () => reject(new Error('upload_failed: network_error'));
+    xhr.onabort = () => reject(new Error('upload_failed: aborted'));
   });
+
+  void (async () => {
+    try {
+      const idToken = await getIdToken();
+      if (!idToken) {
+        rejectDone(new Error('missing_auth_token'));
+        return;
+      }
+
+      const url = `${API_BASE}/api/uploads/requests/${encodeURIComponent(requestId)}?filename=${encodeURIComponent(safeName(file.name))}`;
+      xhr.open('POST', url, true);
+      xhr.responseType = 'text';
+      xhr.setRequestHeader('Authorization', `Bearer ${idToken}`);
+      xhr.setRequestHeader('Content-Type', file.type || 'application/octet-stream');
+      xhr.send(file);
+    } catch (err) {
+      rejectDone(err);
+    }
+  })();
 
   return {
     path,
     done,
     onProgress: (cb) => { listeners.add(cb); return () => listeners.delete(cb); },
-    cancel: () => task.cancel(),
-    task,
+    cancel: () => xhr.abort(),
+    task: xhr,
   };
 }

--- a/frontend/src/screens/MyRequestsPage.jsx
+++ b/frontend/src/screens/MyRequestsPage.jsx
@@ -1,0 +1,237 @@
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
+import PageHeader from "../components/PageHeader";
+import StatusBadge from "../components/StatusBadge";
+import { useAuth } from "../contexts/AuthContext";
+import { useLanguage } from "../contexts/LanguageContext";
+import { apiJson } from "../lib/apiClient";
+import { formatDate, truncate } from "../utils/helpers";
+
+export default function MyRequestsPage() {
+  const { t, lang } = useLanguage();
+  const { user, loading: authLoading } = useAuth();
+  const router = useRouter();
+
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.replace(`/login?next=${encodeURIComponent("/my-requests")}`);
+    }
+  }, [authLoading, user, router]);
+
+  useEffect(() => {
+    if (authLoading || !user) return;
+
+    let alive = true;
+
+    const loadRequests = async () => {
+      setLoading(true);
+      setError("");
+
+      try {
+        const data = await apiJson("/api/requests/mine");
+        if (!alive) return;
+        setItems(Array.isArray(data.items) ? data.items : []);
+      } catch (err) {
+        if (!alive) return;
+        if (err?.status === 401) {
+          router.replace(`/login?next=${encodeURIComponent("/my-requests")}`);
+          return;
+        }
+        setError(err?.status === 404 ? "not_found" : "load_failed");
+      } finally {
+        if (alive) setLoading(false);
+      }
+    };
+
+    loadRequests();
+    return () => {
+      alive = false;
+    };
+  }, [authLoading, user, router]);
+
+  const categoryLabel = (category) =>
+    t.myRequests.categories[category] || category;
+  const urgencyLabel = (urgency) => t.myRequests.urgencies[urgency] || urgency;
+
+  return (
+    <>
+      <PageHeader title={t.myRequests.title} subtitle={t.myRequests.subtitle}>
+        <div
+          style={{
+            marginTop: "22px",
+            display: "flex",
+            justifyContent: "center",
+            flexWrap: "wrap",
+            gap: "10px",
+          }}
+        >
+          <Link href="/requests" className="btn btn-primary btn-sm">
+            {t.myRequests.submitCta}
+          </Link>
+        </div>
+      </PageHeader>
+
+      <div
+        className="page-container"
+        style={{ maxWidth: "1100px", padding: "42px 1.5rem 72px" }}
+      >
+        {loading || authLoading ? (
+          <div
+            className="card"
+            style={{ padding: "28px", textAlign: "center" }}
+          >
+            {t.myRequests.loading}
+          </div>
+        ) : error ? (
+          <div className="card" style={{ padding: "28px" }}>
+            <h2
+              style={{
+                fontSize: "20px",
+                fontWeight: 700,
+                color: "var(--navy)",
+                marginBottom: "8px",
+              }}
+            >
+              {lang === "he"
+                ? "אירעה שגיאה בטעינת הבקשות"
+                : "We could not load your requests"}
+            </h2>
+            <p
+              style={{
+                color: "var(--gray-500)",
+                marginBottom: "18px",
+                lineHeight: 1.7,
+              }}
+            >
+              {lang === "he"
+                ? "נסה/י לרענן את הדף או לחזור שוב מאוחר יותר."
+                : "Try refreshing the page or come back again in a moment."}
+            </p>
+            <button
+              className="btn btn-primary"
+              onClick={() => window.location.reload()}
+            >
+              {lang === "he" ? "רענון" : "Refresh"}
+            </button>
+          </div>
+        ) : items.length === 0 ? (
+          <div
+            className="card"
+            style={{ padding: "34px", textAlign: "center" }}
+          >
+            <h2
+              style={{
+                fontSize: "22px",
+                fontWeight: 700,
+                color: "var(--navy)",
+                marginBottom: "10px",
+              }}
+            >
+              {t.myRequests.empty}
+            </h2>
+            <p
+              style={{
+                color: "var(--gray-500)",
+                marginBottom: "22px",
+                lineHeight: 1.7,
+              }}
+            >
+              {lang === "he"
+                ? "כשתשלח/י בקשה חדשה, היא תופיע כאן עם מספר המעקב והסטטוס שלה."
+                : "When you submit a new request, it will appear here with its tracking number and status."}
+            </p>
+            <Link href="/requests" className="btn btn-primary">
+              {t.myRequests.submitCta}
+            </Link>
+          </div>
+        ) : (
+          <div className="card" style={{ padding: "0", overflow: "hidden" }}>
+            <div style={{ overflowX: "auto" }}>
+              <table style={{ width: "100%", borderCollapse: "collapse" }}>
+                <thead>
+                  <tr style={{ background: "var(--gray-50)" }}>
+                    <th style={thStyle}>{t.myRequests.table.id}</th>
+                    <th style={thStyle}>{t.myRequests.table.category}</th>
+                    <th style={thStyle}>{t.myRequests.table.urgency}</th>
+                    <th style={thStyle}>{t.myRequests.table.status}</th>
+                    <th style={thStyle}>{t.myRequests.table.date}</th>
+                    <th style={thStyle}>{t.myRequests.table.attachments}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((item, index) => (
+                    <tr
+                      key={item.id}
+                      style={{
+                        borderTop: "1px solid var(--gray-200)",
+                        background:
+                          index % 2 ? "var(--white)" : "rgba(250,250,250,0.55)",
+                      }}
+                    >
+                      <td style={tdStyle}>
+                        <div
+                          style={{
+                            fontFamily: "monospace",
+                            fontSize: "13px",
+                            color: "var(--navy)",
+                          }}
+                        >
+                          {item.id}
+                        </div>
+                        <div
+                          style={{
+                            marginTop: "6px",
+                            color: "var(--gray-500)",
+                            fontSize: "13px",
+                          }}
+                        >
+                          {truncate(item.description || "", 72)}
+                        </div>
+                      </td>
+                      <td style={tdStyle}>{categoryLabel(item.category)}</td>
+                      <td style={tdStyle}>{urgencyLabel(item.urgency)}</td>
+                      <td style={tdStyle}>
+                        <StatusBadge status={item.status} />
+                      </td>
+                      <td style={tdStyle}>
+                        {formatDate(item.createdAt, lang) || "—"}
+                      </td>
+                      <td style={tdStyle}>
+                        {Array.isArray(item.attachmentPaths)
+                          ? item.attachmentPaths.length
+                          : 0}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+const thStyle = {
+  textAlign: "start",
+  padding: "16px 18px",
+  fontSize: "13px",
+  color: "var(--gray-500)",
+  fontWeight: 700,
+  letterSpacing: "0.02em",
+  borderBottom: "1px solid var(--gray-200)",
+};
+
+const tdStyle = {
+  padding: "16px 18px",
+  verticalAlign: "top",
+  fontSize: "14px",
+  color: "var(--gray-800)",
+};

--- a/storage.rules
+++ b/storage.rules
@@ -21,16 +21,13 @@ service firebase.storage {
                        || request.auth.token.role == 'admin'
                      );
 
-      // Write: signed-in users with size + MIME limits. The Firestore
-      // request doc may not exist yet at upload time (we upload before
-      // POST /api/requests creates it), so we cannot gate writes on doc
+      // Write: signed-in users with a size limit. The Firestore request
+      // doc may not exist yet at upload time (we upload before POST
+      // /api/requests creates it), so we cannot gate writes on doc
       // ownership. The collision risk is negligible because requestId is
       // a v4 UUID generated client-side.
       allow write: if request.auth != null
-                   && request.resource.size < 10 * 1024 * 1024
-                   && request.resource.contentType.matches(
-                        'application/pdf|image/(jpeg|png)|application/(msword|vnd.openxmlformats-officedocument.wordprocessingml.document)'
-                      );
+                   && request.resource.size < 10 * 1024 * 1024;
     }
 
     // Catch-all: deny everything not explicitly allowed above.


### PR DESCRIPTION
## Summary
UC-01-e completes the UC-01 vertical slice — beneficiaries can now view their own submitted requests.

Plus: folded in a few in-session refinements that make the stack actually work end-to-end (uploads pivot, Admin SDK bucket resolution, dev-friendly CORS, cheaper role check).

## Backend
- `routes/requests.ts`
  - `GET /api/requests/mine` — caller's own requests, newest first, capped at 50. Returns id + selected fields + ISO timestamps.
  - `GET /api/requests/:id` — single read with explicit 403 (owner / handler / admin) on top of Firestore rules.
- `firestore.indexes.json` — composite index `(beneficiaryId ASC, createdAt DESC)`. **Deployed cleanly** to `push-for-fulfillment-staging`.

## Frontend
- `pages/my-requests.tsx` + `screens/MyRequestsPage.jsx` — auth-guarded list view with loading / empty / error states; renders a table with category, urgency, status badge (existing `<StatusBadge />`), date, attachment count.
- `components/Navbar.jsx` — "My Requests" link appears for beneficiaries on desktop + mobile menus.
- `src/data/translations.js` — `t.myRequests` block in HE + EN.

## Folded-in refinements (Copilot-assisted, kept because they make things work)

**Uploads pivot — backend-proxied instead of direct-to-Storage**
- NEW `backend/src/routes/uploads.ts` — `POST /api/uploads/requests/:requestId?filename=...` accepts raw bytes (≤10MB), verifies the ID token, writes to Storage via Admin SDK, returns `{ path, downloadURL }`.
- `frontend/src/lib/storage.ts` rewritten — `XMLHttpRequest` against the backend, same `{ path, done, onProgress, cancel }` external contract so `UploadArea.jsx` didn't need any changes.
- `storage.rules` — dropped the client-side MIME enforcement (Admin SDK writes bypass rules anyway), kept the 10MB cap as defense-in-depth.
- Why: direct-from-browser uploads hit CORS / region issues. Server-proxied is the documented backstop and we already had the Admin SDK initialized.

**Admin SDK bucket resolution**
- `backend/src/lib/firebaseAdmin.ts` — `resolveStorageBucketName()` reads from `FIREBASE_STORAGE_BUCKET` / `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` / `GOOGLE_CLOUD_STORAGE_BUCKET`, normalizes both `.appspot.com` and `.firebasestorage.app` suffixes, and falls back to the project id. `admin.initializeApp({ storageBucket })` now actually points somewhere.

**CORS dev convenience**
- `backend/src/index.ts` — regex match for any `http://localhost:*` / `http://127.0.0.1:*` origin alongside `FRONTEND_ORIGIN`. Production still uses the env-pinned origin.

**Cheaper register**
- `backend/src/routes/auth.ts` — the existing-role check now reads from the verified token claim instead of an extra `getUser()` call. Same behavior, one less RPC per register.

## Test plan
- [x] `backend/ npm run type-check` clean
- [x] `frontend/ npm run build` clean (9 routes, `/my-requests` 2.79kB)
- [x] `backend npm run dev` boots; `curl /api/requests/mine` without token → 401
- [x] `firebase deploy --only firestore:indexes` applied the composite index
- [ ] Manual: beneficiary A submits 2 requests → `/my-requests` lists both
- [ ] Manual: beneficiary B signs in → `/my-requests` empty (rule enforcement)
- [ ] Manual: upload a 2MB PDF in step 3 of `/requests` → file at `requests/<uuid>/foo.pdf` in Storage console
- [ ] HE/EN: switch language on `/my-requests` → labels swap

Closes #29