### PR TITLE
fix(uc-01): gender M/F/O mapping + /requests auth-guard flash

### DIFF
--- a/frontend/src/screens/RequestsPage.jsx
+++ b/frontend/src/screens/RequestsPage.jsx
@@ -53,11 +53,20 @@ export default function RequestsPage() {
   }, [])
 
   // Auth guard — if signed out, send to /login with a next= back to here.
+  // The early-return below the form definition stops the form rendering
+  // for a frame between the redirect being scheduled and the navigation
+  // committing.
   useEffect(() => {
     if (!authLoading && !user) {
       router.replace(`/login?next=${encodeURIComponent('/requests')}`)
     }
   }, [authLoading, user, router])
+
+  // Map the UI's short gender codes (M/F/O) to the backend's canonical
+  // enum (male/female/other). The backend (UC-01-c) is the source of truth
+  // for the request-doc schema; the UI happens to use shorter codes.
+  const GENDER_MAP = { M: 'male', F: 'female', O: 'other', '': '' }
+  const toCanonicalGender = (g) => GENDER_MAP[g] ?? ''
 
   const rq = t.request
   const steps = [rq.steps.personal, rq.steps.type, rq.steps.documents, rq.steps.confirm]
@@ -94,7 +103,7 @@ export default function RequestsPage() {
         email:     values.email,
         city:      values.city,
         age:       Number(values.age) || 0,
-        gender:    values.gender || '',
+        gender:    toCanonicalGender(values.gender),
         category:  values.category,
         description: values.description,
         urgency:   values.urgency,
@@ -127,6 +136,19 @@ export default function RequestsPage() {
   const handleCopy = async () => {
     const ok = await copyToClipboard(trackingId)
     toast(ok ? t.common.copied : t.common.error, ok ? 'success' : 'error')
+  }
+
+  // ── AUTH GATE ─────────────────────────────────────────────
+  // While auth is still resolving, or after we've determined the user is
+  // signed out, render nothing so the form is never visible to a
+  // signed-out caller (the useEffect above is already scheduling the
+  // redirect; this just avoids the one-frame flash).
+  if (authLoading || !user) {
+    return (
+      <div className="page-container" style={{ padding: '80px 24px', textAlign: 'center' }}>
+        <div style={{ color: 'var(--gray-500)' }}>{t.common.loading}</div>
+      </div>
+    )
   }
 
   // ── SUCCESS SCREEN ────────────────────────────────────────


### PR DESCRIPTION
## Summary
Two issues caught by a manual browser test pass against `uc-01-manual-test-guide.md`. Both in the form screen, both 1-file fixes.

### 1. Gender validation fail (P0 — blocks every submit)
The form uses radio values **M / F / O** (from the ported prototype). The backend zod enum requires **`'male' | 'female' | 'other' | ''`**. So every submission was returning:
```
400 {"error":"validation","fieldErrors":{"gender":["Invalid enum value. Expected 'male' | 'female' | 'other' | '', received 'M'"]}}
```
**Fix:** introduce a `GENDER_MAP` in `RequestsPage.jsx` and apply `toCanonicalGender(values.gender)` when building the POST payload. The backend remains the source of truth for the canonical vocabulary; the UI just maps.

### 2. `/requests` auth guard flash (P1 — security UX)
The previous guard was a `useEffect` that scheduled `router.replace(...)`. Since `useEffect` runs *after* commit, the form rendered for one frame before the redirect navigated away — meaning a signed-out user could briefly see (and partially interact with) the form.
**Fix:** early-return a loading placeholder while `authLoading || !user`. The `useEffect` still fires the redirect; the form is now never visible to a signed-out caller.

## Test plan
- [x] `npm run build` clean
- [x] `e2e-uc01-smoke.mjs` 14/14 (no regression)
- [ ] Manual: `/requests` in incognito → spinner, then `/login?next=%2Frequests` with **no form flash**
- [ ] Manual: submit form with gender = "Other" → 201 + Firestore doc shows `gender: "other"`
- [ ] Manual: re-run section A1–C5 of `sem2/docs/uc-01-manual-test-guide.md` — both previously-failing cases now pass

## Bonus
Expanded `sem2/docs/uc-01-manual-test-guide.md` from ~14 → 72 individual checks: file-upload edge cases (PNG, JPEG, 11MB rejection, cancel mid-upload), network resilience (kill backend mid-submit / mid-upload), i18n persistence, admin role flow (set-admin CLI + nav visibility + cross-user read), and Firestore + Storage rule denial at the SDK layer (not just the API layer). Lives outside the team repo for now; happy to move to the wiki Test Plan when that's drafted.